### PR TITLE
chore: update actions to use node 24 instead of deprecated node 20

### DIFF
--- a/.github/workflows/remove-stale.yaml
+++ b/.github/workflows/remove-stale.yaml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Fetch gh-pages branch
         run: git fetch origin gh-pages --depth=1
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Description

- Update actions to use node 24 instead of deprecated node 20

<img width="1370" height="1016" alt="image" src="https://github.com/user-attachments/assets/47e9ce17-86b3-4678-84cf-4d5ca185f759" />
